### PR TITLE
Upgrade jszip and async to later versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
     "url": "https://github.com/Mostafa-Samir/zip-local.git"
   },
   "dependencies": {
-    "async": "^1.4.2",
+    "async": "^3.2.4",
     "graceful-fs": "^4.1.3",
-    "jszip": "^2.6.1",
+    "jszip": "^2.7.0",
     "q": "^1.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This will reduce some of the exposure to known vulnerabilities. Unfortunately, there's a need for a breaking change to include upgrading to JSzip 3 in order to completely remove known vulnerabilities.

Resolves #16 